### PR TITLE
fix: bug #61 dev server open flag

### DIFF
--- a/packages/create-stati/src/constants.ts
+++ b/packages/create-stati/src/constants.ts
@@ -49,7 +49,7 @@ export const SASS_CONFIG: CSSProcessorConfig = {
     'build:css': 'sass styles/main.scss public/styles.css --style=compressed',
     'watch:css': 'sass styles/main.scss public/styles.css --watch',
     build: 'npm run build:css && stati build',
-    dev: 'concurrently --prefix none "npm run watch:css" "stati dev"',
+    dev: 'concurrently --prefix none -P "npm run watch:css" "stati dev {@}"',
   },
 };
 

--- a/packages/create-stati/test/css-processors.test.ts
+++ b/packages/create-stati/test/css-processors.test.ts
@@ -113,7 +113,7 @@ describe('CSSProcessor', () => {
 
       // Scripts should be modified to integrate CSS processing
       expect(packageJson.scripts.dev).toBe(
-        'concurrently --prefix none "npm run watch:css" "stati dev"',
+        'concurrently --prefix none -P "npm run watch:css" "stati dev {@}"',
       );
       expect(packageJson.scripts.build).toBe('npm run build:css && stati build');
     });


### PR DESCRIPTION
Resolves #61 

### Problem:
`npm run dev -- --open` (the classic way of passing down an extra flag) not working because dev script is using `concurrently`

### Resolution:
[concurrently](https://github.com/open-cli-tools/concurrently/blob/2c30e74081d130bf1b3a08cb0a8247df2a79f82f/docs/cli/passthrough-arguments.md) supports cli  arguments passthrough, but the documentation assuming npm scripts will be called, so it has an extra `--` in the examples.

With the passthrough `-P` flag, we can pass down the `--open` flag like this:
`npm run dev -- --open`
