### PR TITLE
fix(dev-server): address memory leak during development sessions

### DIFF
--- a/.changeset/dev-server-leak-fix.md
+++ b/.changeset/dev-server-leak-fix.md
@@ -1,5 +1,0 @@
----
-'@stati/core': patch
----
-
-Fix dev server memory leak and rebuild-time growth by reusing the markdown-it and Eta engines across rebuilds.

--- a/.changeset/dev-server-leak-fix.md
+++ b/.changeset/dev-server-leak-fix.md
@@ -1,0 +1,5 @@
+---
+'@stati/core': patch
+---
+
+Fix dev server memory leak and rebuild-time growth by reusing the markdown-it and Eta engines across rebuilds.

--- a/.changeset/witty-cat-plays-mqydst5h.md
+++ b/.changeset/witty-cat-plays-mqydst5h.md
@@ -1,0 +1,9 @@
+---
+"@stati/core": patch
+"@stati/cli": patch
+"create-stati": patch
+---
+
+address memory leak during development sessions
+
+Added a dedicated test for memory leaks in the dev server by

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "vitest run",
+    "test:dev-leak": "vitest run -c vitest.leak.config.ts",
     "test:create-stati": "npm run build -w packages/create-stati && cd examples && node ../packages/create-stati/dist/index.js test-scaffolded",
     "test:create-stati:cleanup": "node -e \"require('node:fs').rmSync('examples/test-scaffolded', { recursive: true, force: true })\"",
     "lint": "eslint . --ext .ts",
@@ -17,7 +18,7 @@
     "test:blank:preview": "npm run build && cd examples/blank && npm run preview",
     "test:blank:clean": "cd examples/blank && npm run clean",
     "test:blank:full": "npm run test:blank:clean && npm run test:blank:build && echo Build completed successfully!",
-    "test:ci": "npm run build && npm run lint:ci && npm run typecheck:ci && npm run test --workspaces --if-present",
+    "test:ci": "npm run build && npm run lint:ci && npm run typecheck:ci && npm run test --workspaces --if-present && npm run test:dev-leak",
     "changeset": "changeset",
     "changeset:status": "changeset status",
     "changeset:generate": "node scripts/generate-changesets.mjs",

--- a/packages/core/src/core/dev.ts
+++ b/packages/core/src/core/dev.ts
@@ -9,6 +9,7 @@ import type { FSWatcher } from 'chokidar';
 import { build } from './build.js';
 import { invalidate } from './invalidate.js';
 import { loadConfig } from '../config/loader.js';
+import { clearTemplateEngineCache } from './templates.js';
 import {
   loadCacheManifest,
   saveCacheManifest,
@@ -322,6 +323,11 @@ async function handleTemplateChange(
   const cacheDir = resolveCacheDir();
 
   try {
+    // Drop the cached Eta engine so the changed template (and any compiled partials)
+    // are recompiled on the next build. This keeps rebuilds correct while still
+    // reusing the engine across the common markdown-only edit path.
+    clearTemplateEngineCache();
+
     // Load existing cache manifest
     const cacheManifest = await loadCacheManifest(cacheDir);
 
@@ -993,6 +999,9 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
         });
         httpServer = null;
       }
+
+      // Release cached dev-session engines so they can be garbage collected
+      clearTemplateEngineCache();
 
       logger.info?.('Dev server stopped');
     },

--- a/packages/core/src/core/dev.ts
+++ b/packages/core/src/core/dev.ts
@@ -10,6 +10,7 @@ import { build } from './build.js';
 import { invalidate } from './invalidate.js';
 import { loadConfig } from '../config/loader.js';
 import { clearTemplateEngineCache } from './templates.js';
+import { clearMarkdownProcessorCache } from './markdown.js';
 import {
   loadCacheManifest,
   saveCacheManifest,
@@ -1002,6 +1003,7 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
 
       // Release cached dev-session engines so they can be garbage collected
       clearTemplateEngineCache();
+      clearMarkdownProcessorCache();
 
       logger.info?.('Dev server stopped');
     },

--- a/packages/core/src/core/templates.ts
+++ b/packages/core/src/core/templates.ts
@@ -230,15 +230,48 @@ async function discoverPartials(
   return partials;
 }
 
+/**
+ * Cached template engine for dev mode to avoid re-creating on each rebuild.
+ *
+ * Recreating the Eta instance and recompiling every template on each dev rebuild
+ * generates large transient native allocations that the V8 allocator does not
+ * return to the OS, causing monotonic RSS growth and increasing rebuild times
+ * over a long dev session. Reusing a single instance (with template caching on)
+ * keeps rebuild cost flat. The cache is keyed by template directory so a config
+ * change pointing to a different srcDir still produces a fresh engine.
+ */
+let cachedTemplateEngine: { templateDir: string; eta: Eta } | null = null;
+
+/**
+ * Clear the cached template engine. Call this when templates change in dev mode
+ * so the next build recompiles them, or when shutting down a dev session.
+ */
+export function clearTemplateEngineCache(): void {
+  cachedTemplateEngine = null;
+}
+
 export function createTemplateEngine(config: StatiConfig): Eta {
   const templateDir = resolveSrcDir(config);
 
+  // In dev mode, reuse a single cached engine across rebuilds to avoid
+  // per-rebuild compile churn and the associated native-memory growth.
+  if (isDevelopment() && cachedTemplateEngine && cachedTemplateEngine.templateDir === templateDir) {
+    return cachedTemplateEngine.eta;
+  }
+
+  // Enable the template cache in dev too so partials/layouts compile once and are
+  // reused across rebuilds; template edits clear this cache via clearTemplateEngineCache().
+  const useCache = isDevelopment() || isProduction();
   const eta = new Eta({
     views: templateDir,
-    cache: isProduction(),
-    cacheFilepaths: isProduction(),
+    cache: useCache,
+    cacheFilepaths: useCache,
     varName: 'stati',
   });
+
+  if (isDevelopment()) {
+    cachedTemplateEngine = { templateDir, eta };
+  }
 
   return eta;
 }

--- a/packages/core/test/core/templates.test.ts
+++ b/packages/core/test/core/templates.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTemplateEngine, renderPage } from '../../src/core/templates.js';
+import {
+  createTemplateEngine,
+  clearTemplateEngineCache,
+  renderPage,
+} from '../../src/core/templates.js';
 import type { StatiConfig, PageModel } from '../../src/types/index.js';
 import type { Eta } from 'eta';
 import { join } from 'node:path';
 
 // Create hoisted mocks
-const { mockPathExists, mockGlob, MockEta } = vi.hoisted(() => ({
-  mockPathExists: vi.fn(),
-  mockGlob: vi.fn(),
-  MockEta: vi.fn(),
-}));
+const { mockPathExists, mockGlob, MockEta, mockIsDevelopment, mockIsProduction } = vi.hoisted(
+  () => ({
+    mockPathExists: vi.fn(),
+    mockGlob: vi.fn(),
+    MockEta: vi.fn(),
+    mockIsDevelopment: vi.fn(),
+    mockIsProduction: vi.fn(),
+  }),
+);
 
 // Mock dependencies
 vi.mock('fs-extra', () => ({
@@ -24,6 +32,11 @@ vi.mock('fast-glob', () => ({
 
 vi.mock('eta', () => ({
   Eta: MockEta,
+}));
+
+vi.mock('../../src/env.js', () => ({
+  isDevelopment: () => mockIsDevelopment(),
+  isProduction: () => mockIsProduction(),
 }));
 
 describe('templates.ts', () => {
@@ -59,6 +72,9 @@ describe('templates.ts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(process, 'cwd').mockReturnValue(mockProjectRoot);
+    clearTemplateEngineCache();
+    mockIsDevelopment.mockReturnValue(false);
+    mockIsProduction.mockReturnValue(false);
 
     mockEtaInstance = {
       renderAsync: vi.fn(),
@@ -79,6 +95,16 @@ describe('templates.ts', () => {
         varName: 'stati',
       });
       expect(eta).toBe(mockEtaInstance);
+    });
+
+    it('should reuse cached Eta instance in development for the same template directory', () => {
+      mockIsDevelopment.mockReturnValue(true);
+
+      const firstEta = createTemplateEngine(mockConfig);
+      const secondEta = createTemplateEngine(mockConfig);
+
+      expect(MockEta).toHaveBeenCalledTimes(1);
+      expect(secondEta).toBe(firstEta);
     });
   });
 

--- a/packages/core/test/perf/dev-server-leak.test.ts
+++ b/packages/core/test/perf/dev-server-leak.test.ts
@@ -14,9 +14,10 @@
  *
  * Run locally / in CI with accurate heap detection:
  *   npm run test:dev-leak
- * (that script passes --expose-gc). Without --expose-gc the heap assertions are
- * skipped and only rebuild-time stability is checked, so it still works in a
- * normal `vitest run`.
+ * This test is excluded from the default Vitest config and runs via
+ * `vitest.leak.config.ts`, which uses fork `execArgv: ['--expose-gc']`.
+ * Without `--expose-gc`, heap assertions are skipped and only rebuild-time
+ * stability is checked.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/core/test/perf/dev-server-leak.test.ts
+++ b/packages/core/test/perf/dev-server-leak.test.ts
@@ -41,7 +41,7 @@ const LEAK_CONFIG = {
   rebuilds: 50,
   /** Test timeout */
   timeout: 180000,
-  /** Max acceptable RSS growth across the whole session, in MB (gc available) */
+  /** Max acceptable heap growth across the whole session, in MB (gc available) */
   maxHeapGrowthMb: 25,
   /** Max ratio of late-window rebuild time vs early-window rebuild time */
   maxRebuildTimeRatio: 1.6,

--- a/packages/core/test/perf/dev-server-leak.test.ts
+++ b/packages/core/test/perf/dev-server-leak.test.ts
@@ -38,7 +38,7 @@ const LEAK_CONFIG = {
   /** Warmup rebuilds before measuring */
   warmupRebuilds: 5,
   /** Measured rebuilds */
-  rebuilds: 50,
+  rebuilds: 100,
   /** Test timeout */
   timeout: 180000,
   /** Max acceptable heap growth across the whole session, in MB (gc available) */

--- a/packages/core/test/perf/dev-server-leak.test.ts
+++ b/packages/core/test/perf/dev-server-leak.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Dev-server leak / rebuild-time accumulation regression tests.
+ *
+ * These tests simulate a long dev session by repeatedly editing the site the way
+ * a developer would: mostly markdown content edits, with periodic template/layout
+ * and static-asset edits. The template path re-renders nearly every page and is
+ * the heaviest; markdown/static edits reuse the engines. A leak shows up as:
+ *   - monotonically increasing rebuild time, and/or
+ *   - monotonically increasing live heap after a forced GC.
+ *
+ * The fix (reusing the markdown-it + Eta engines across rebuilds) keeps both
+ * flat. These tests assert that flatness so the regression cannot silently
+ * return.
+ *
+ * Run locally / in CI with accurate heap detection:
+ *   npm run test:dev-leak
+ * (that script passes --expose-gc). Without --expose-gc the heap assertions are
+ * skipped and only rebuild-time stability is checked, so it still works in a
+ * normal `vitest run`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { build } from '../../src/core/build.js';
+import { clearTemplateEngineCache } from '../../src/core/templates.js';
+import { clearMarkdownProcessorCache } from '../../src/core/markdown.js';
+import { setEnv } from '../../src/env.js';
+
+const LEAK_CONFIG = {
+  /** Pages to render each rebuild (more pages = clearer signal) */
+  pageCount: 40,
+  /** Warmup rebuilds before measuring */
+  warmupRebuilds: 5,
+  /** Measured rebuilds */
+  rebuilds: 50,
+  /** Test timeout */
+  timeout: 180000,
+  /** Max acceptable RSS growth across the whole session, in MB (gc available) */
+  maxHeapGrowthMb: 25,
+  /** Max ratio of late-window rebuild time vs early-window rebuild time */
+  maxRebuildTimeRatio: 1.6,
+};
+
+function createSilentLogger() {
+  return {
+    info: () => {},
+    success: () => {},
+    warning: () => {},
+    error: () => {},
+    status: () => {},
+    building: () => {},
+    processing: () => {},
+    stats: () => {},
+  };
+}
+
+function createTestFixture(baseDir: string, pageCount: number): void {
+  const siteDir = join(baseDir, 'site');
+  const publicDir = join(baseDir, 'public');
+  const partialsDir = join(siteDir, '_partials');
+  mkdirSync(siteDir, { recursive: true });
+  mkdirSync(publicDir, { recursive: true });
+  mkdirSync(partialsDir, { recursive: true });
+
+  // A header partial so layout edits cascade through partial compilation too.
+  writeFileSync(
+    join(partialsDir, 'header.eta'),
+    `<% if (!stati.props) { %><% return; } %><header><%= stati.props.title || 'Site' %></header>`,
+  );
+
+  for (let i = 0; i < pageCount; i++) {
+    writeFileSync(
+      join(siteDir, `page-${i}.md`),
+      `---\ntitle: Page ${i}\ndescription: Page number ${i}\n---\n\n# Page ${i}\n\nLorem ipsum dolor sit amet.\n\n## Section\n\nMore content here.\n`,
+    );
+  }
+  writeFileSync(join(siteDir, 'index.md'), `---\ntitle: Home\n---\n\n# Home\n`);
+  writeFileSync(join(publicDir, 'styles.css'), 'body { margin: 0; }');
+
+  writeFileSync(
+    join(baseDir, 'stati.config.js'),
+    `export default { site: { title: 'Leak Test', baseUrl: 'https://test.example.com' }, srcDir: 'site', outDir: 'dist', staticDir: 'public' };\n`,
+  );
+}
+
+function writeLayout(siteDir: string, marker: number): void {
+  // Each marker change forces a real recompile + full re-render of all pages,
+  // mirroring the heaviest dev-server edit path.
+  writeFileSync(
+    join(siteDir, 'layout.eta'),
+    `<!DOCTYPE html>
+<html>
+<head><title><%= stati.page.title %> | rev ${marker}</title></head>
+<body>
+  <%~ stati.partials.header({ title: 'rev ${marker}' }) %>
+  <main><%~ stati.content %></main>
+  <footer>rev ${marker}</footer>
+</body>
+</html>`,
+  );
+}
+
+function writeMarkdown(siteDir: string, page: number, marker: number): void {
+  // A typical content edit: single page, no template recompile needed.
+  writeFileSync(
+    join(siteDir, `page-${page}.md`),
+    `---\ntitle: Page ${page}\ndescription: Page number ${page}\n---\n\n# Page ${page}\n\nLorem ipsum dolor sit amet (rev ${marker}).\n\n## Section\n\nMore content here.\n`,
+  );
+}
+
+function writeStatic(publicDir: string, marker: number): void {
+  // A static asset edit triggers a full rebuild + asset copy.
+  writeFileSync(join(publicDir, 'styles.css'), `body { margin: ${marker % 4}px; }`);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+/** Force GC if exposed; returns true when GC was actually run. */
+async function forceGc(): Promise<boolean> {
+  const gc = (globalThis as { gc?: () => void }).gc;
+  if (!gc) return false;
+  gc();
+  await sleep(0);
+  gc();
+  return true;
+}
+
+describe('Dev server rebuild leak regression', () => {
+  let testDir: string;
+  let originalCwd: string;
+
+  beforeAll(() => {
+    testDir = join(tmpdir(), `stati-leak-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    createTestFixture(testDir, LEAK_CONFIG.pageCount);
+    writeLayout(join(testDir, 'site'), 0);
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    setEnv('development');
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    clearTemplateEngineCache();
+    clearMarkdownProcessorCache();
+    setEnv('test');
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it(
+    'keeps rebuild time and heap flat across a realistic mixed-edit session',
+    async () => {
+      const siteDir = join(testDir, 'site');
+      const publicDir = join(testDir, 'public');
+
+      // Warm cache + engines.
+      await build({ clean: true, force: true, logger: createSilentLogger() });
+
+      const durations: number[] = [];
+      const heaps: number[] = [];
+      const gcAvailable = await forceGc();
+
+      for (let i = 0; i < LEAK_CONFIG.warmupRebuilds + LEAK_CONFIG.rebuilds; i++) {
+        // Mirror a real dev session: mostly markdown edits, periodic template
+        // and static-asset edits. Template edits clear the engine cache exactly
+        // like the dev server does; markdown/static edits reuse the engine.
+        let force = false;
+        if (i % 7 === 0) {
+          writeLayout(siteDir, i + 1);
+          clearTemplateEngineCache();
+          force = true;
+        } else if (i % 11 === 0) {
+          writeStatic(publicDir, i + 1);
+        } else {
+          writeMarkdown(siteDir, i % LEAK_CONFIG.pageCount, i + 1);
+        }
+
+        const start = performance.now();
+        await build({ force, logger: createSilentLogger() });
+        const elapsed = performance.now() - start;
+
+        if (i >= LEAK_CONFIG.warmupRebuilds) {
+          durations.push(elapsed);
+          if (gcAvailable) {
+            await forceGc();
+            heaps.push(process.memoryUsage().heapUsed / 1024 / 1024);
+          }
+        }
+      }
+
+      const window = Math.max(3, Math.floor(durations.length / 5));
+      const earlyMedian = median(durations.slice(0, window));
+      const lateMedian = median(durations.slice(-window));
+
+      console.warn(
+        `[LEAK] rebuilds early=${earlyMedian.toFixed(0)}ms late=${lateMedian.toFixed(0)}ms gc=${gcAvailable}`,
+      );
+
+      // Rebuild time must not creep upward over the session.
+      expect(lateMedian).toBeLessThan(earlyMedian * LEAK_CONFIG.maxRebuildTimeRatio);
+
+      if (gcAvailable && heaps.length > 0) {
+        const heapGrowth = heaps[heaps.length - 1]! - heaps[0]!;
+        console.warn(`[LEAK] heap growth=${heapGrowth.toFixed(1)}MB over ${heaps.length} rebuilds`);
+        expect(heapGrowth).toBeLessThan(LEAK_CONFIG.maxHeapGrowthMb);
+      } else {
+        console.warn('[LEAK] --expose-gc not set; skipping heap assertion');
+      }
+    },
+    LEAK_CONFIG.timeout,
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import { configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -7,6 +8,8 @@ export default defineConfig({
     globals: false,
     mockReset: true,
     restoreMocks: true,
+    // The dev-server leak test needs --expose-gc; it runs via its own config (npm run test:dev-leak)
+    exclude: [...configDefaults.exclude, '**/perf/dev-server-leak.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],

--- a/vitest.leak.config.ts
+++ b/vitest.leak.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Dedicated Vitest config for the dev-server leak regression test.
+ *
+ * Runs in a forked worker with `--expose-gc` so the test can force GC and assert
+ * that live heap stays flat across many template rebuilds. Used by `npm run test:dev-leak`.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['packages/core/test/perf/dev-server-leak.test.ts'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        execArgv: ['--expose-gc'],
+      },
+    },
+  },
+  esbuild: {
+    target: 'node18',
+  },
+});


### PR DESCRIPTION
Added a dedicated test for memory leaks in the dev server by reusing template engines across rebuilds. Introduced a new script for leak testing and updated Vitest configuration to support garbage collection assertions. This ensures stable rebuild times and prevents memory accumulation during long development sessions.