### PR TITLE
feat(dev-server): add CSS watcher diagnostics and slowdown check script

### DIFF
--- a/.changeset/proud-eagle-dreams-mqyxlog9.md
+++ b/.changeset/proud-eagle-dreams-mqyxlog9.md
@@ -1,0 +1,9 @@
+---
+"@stati/core": minor
+"@stati/cli": minor
+"create-stati": minor
+---
+
+add CSS watcher diagnostics and slowdown check script
+
+- Introduced a new script to check for dev server rebuild slowdown.

--- a/.github/workflows/dev-server-slowdown.yml
+++ b/.github/workflows/dev-server-slowdown.yml
@@ -1,0 +1,91 @@
+name: Dev Server Slowdown Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+# Prevent multiple runs for the same PR update.
+concurrency:
+  group: dev-server-slowdown-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-slowdown:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core package
+        run: npm run build -w packages/core
+
+      - name: Run dev-server slowdown check
+        id: slowdown
+        continue-on-error: true
+        env:
+          STATI_DEV_CHECK_REPORT_PATH: dev-server-slowdown-report.md
+        run: npm run test:dev-rebuild-slowdown
+
+      - name: Comment PR with slowdown stats
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'dev-server-slowdown-report.md';
+            const COMMENT_MARKER = '<!-- stati-dev-server-slowdown-report -->';
+
+            let report = '## Dev Server Slowdown Check\n\nNo slowdown report was generated.';
+            if (fs.existsSync(path)) {
+              report = fs.readFileSync(path, 'utf-8');
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.body.includes(COMMENT_MARKER),
+            );
+
+            const body = `${COMMENT_MARKER}\n${report}`;
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              console.log(`Updated slowdown comment #${existingComment.id}`);
+            } else {
+              const { data: newComment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              console.log(`Created slowdown comment #${newComment.id}`);
+            }
+
+      - name: Fail if slowdown detected
+        if: ${{ steps.slowdown.outcome == 'failure' }}
+        run: |
+          echo "Dev server slowdown check failed"
+          exit 1

--- a/.github/workflows/dev-server-slowdown.yml
+++ b/.github/workflows/dev-server-slowdown.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 # Prevent multiple runs for the same PR update.
 concurrency:
@@ -41,7 +42,7 @@ jobs:
         run: npm run test:dev-rebuild-slowdown
 
       - name: Comment PR with slowdown stats
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/dev-server-slowdown.yml
+++ b/.github/workflows/dev-server-slowdown.yml
@@ -54,34 +54,40 @@ jobs:
               report = fs.readFileSync(path, 'utf-8');
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existingComment = comments.find((comment) =>
-              comment.body.includes(COMMENT_MARKER),
-            );
-
-            const body = `${COMMENT_MARKER}\n${report}`;
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              });
-              console.log(`Updated slowdown comment #${existingComment.id}`);
-            } else {
-              const { data: newComment } = await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
               });
-              console.log(`Created slowdown comment #${newComment.id}`);
+
+              const existingComment = comments.find((comment) =>
+                comment.body.includes(COMMENT_MARKER),
+              );
+
+              const body = `${COMMENT_MARKER}\n${report}`;
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+                console.log(`Updated slowdown comment #${existingComment.id}`);
+              } else {
+                const { data: newComment } = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+                console.log(`Created slowdown comment #${newComment.id}`);
+              }
+            } catch (error) {
+              // Some PR contexts (for example, forked or restricted bot runs) deny comment writes.
+              // Keep the workflow focused on slowdown detection rather than comment permissions.
+              core.warning(`Skipping slowdown PR comment: ${error.message}`);
             }
 
       - name: Fail if slowdown detected

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "test:dev-leak": "vitest run -c vitest.leak.config.ts",
+    "test:dev-rebuild-slowdown": "node scripts/check-dev-server-slowdown.mjs",
     "test:create-stati": "npm run build -w packages/create-stati && cd examples && node ../packages/create-stati/dist/index.js test-scaffolded",
     "test:create-stati:cleanup": "node -e \"require('node:fs').rmSync('examples/test-scaffolded', { recursive: true, force: true })\"",
     "lint": "eslint . --ext .ts",

--- a/packages/core/src/core/dev.ts
+++ b/packages/core/src/core/dev.ts
@@ -29,6 +29,8 @@ import {
   createFallbackLogger,
   mergeServerOptions,
   createTypeScriptWatcher,
+  isEnabledEnvFlag,
+  refreshCssOutputWatcher,
   normalizePathForComparison,
   isPathWithinDirectory,
 } from './utils/index.js';
@@ -131,6 +133,7 @@ async function performInitialBuild(
  *   active build. The `changes` Map stores file paths as keys and their event types as values,
  *   ensuring each file is only processed once with its most recent event type.
  * @param onError - Optional callback invoked when build errors occur
+ * @param onBuildEnd - Optional callback invoked after each build attempt finishes (success or failure)
  * @param batchedChanges - Array of changes to process in a single batch (used for pending queue processing)
  */
 async function performIncrementalRebuild(
@@ -143,6 +146,7 @@ async function performIncrementalRebuild(
   isBuildingRef: { value: boolean },
   pendingChangesRef: { changes: Map<string, 'add' | 'change' | 'unlink'> },
   onError?: (error: Error | null) => void,
+  onBuildEnd?: () => Promise<void> | void,
   batchedChanges: Array<{ path: string; eventType: 'add' | 'change' | 'unlink' }> = [],
 ): Promise<void> {
   // If a build is in progress, queue this change for processing after the current build
@@ -270,6 +274,16 @@ async function performIncrementalRebuild(
   } finally {
     isBuildingRef.value = false;
 
+    if (onBuildEnd) {
+      try {
+        await onBuildEnd();
+      } catch (error) {
+        logger.error?.(
+          `Failed CSS watcher refresh after build: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
     // Check if there are pending changes that occurred during this build
     if (pendingChangesRef.changes.size > 0) {
       // Get all pending changes - the build will process all of them at once
@@ -292,6 +306,7 @@ async function performIncrementalRebuild(
           isBuildingRef,
           pendingChangesRef,
           onError,
+          onBuildEnd,
           remaining, // Pass remaining changes as batched
         );
       }
@@ -534,6 +549,11 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
   const isBuildingRef = { value: false };
   const pendingChangesRef = { changes: new Map<string, 'add' | 'change' | 'unlink'>() };
   let isStopping = false;
+  const watchedCssFiles = new Set<string>();
+
+  // Diagnostics toggles used for investigating dev-server rebuild slowdown.
+  const disableCssWatcher = isEnabledEnvFlag(process.env.STATI_DEV_DISABLE_CSS_WATCHER);
+  const disableWsReload = isEnabledEnvFlag(process.env.STATI_DEV_DISABLE_WS_RELOAD);
 
   /**
    * Gets MIME type for a file based on its extension
@@ -839,7 +859,7 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
             onRebuild: (_results, compileTimeMs) => {
               logger.info?.(`▸ TypeScript recompiled in ${compileTimeMs}ms`);
               // Broadcast reload to WebSocket clients
-              if (wsServer) {
+              if (wsServer && !disableWsReload) {
                 wsServer.clients.forEach((client: unknown) => {
                   const ws = client as { readyState: number; send: (data: string) => void };
                   if (ws.readyState === 1) {
@@ -874,28 +894,24 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
         ignoreInitial: true,
       });
 
-      // Set up separate watcher for CSS files in output directory
-      // This enables live reload when external tools (like Tailwind CLI) update CSS
-      cssWatcher = chokidar.watch([join(outDir, '**/*.css')], {
-        ignored: /(^|[/\\])\../, // ignore dotfiles
-        persistent: true,
-        ignoreInitial: true,
-      });
+      const refreshCssWatcher = async (): Promise<void> => {
+        cssWatcher = await refreshCssOutputWatcher({
+          outDir,
+          logger,
+          wsServer,
+          disableWsReload,
+          cssWatcher,
+          watchedCssFiles,
+        });
+      };
 
-      cssWatcher.on('change', (path: string) => {
-        const relativePath = path.replace(process.cwd(), '').replace(/\\/g, '/').replace(/^\//, '');
-        logger.info?.(`▸ ${relativePath} updated`);
+      if (!disableCssWatcher) {
+        await refreshCssWatcher();
 
-        // Just notify clients to reload - no rebuild needed since CSS was already compiled
-        if (wsServer) {
-          wsServer.clients.forEach((client: unknown) => {
-            const ws = client as { readyState: number; send: (data: string) => void };
-            if (ws.readyState === 1) {
-              ws.send(JSON.stringify({ type: 'reload' }));
-            }
-          });
+        if (!cssWatcher) {
+          logger.info?.('  • [dev] No CSS files found in output; CSS watcher not started');
         }
-      });
+      }
 
       watcher.on('change', (path: string) => {
         void performIncrementalRebuild(
@@ -904,10 +920,11 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
           configPath,
           staticDir,
           logger,
-          wsServer,
+          disableWsReload ? null : wsServer,
           isBuildingRef,
           pendingChangesRef,
           setLastBuildError,
+          disableCssWatcher ? undefined : refreshCssWatcher,
         );
       });
 
@@ -918,10 +935,11 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
           configPath,
           staticDir,
           logger,
-          wsServer,
+          disableWsReload ? null : wsServer,
           isBuildingRef,
           pendingChangesRef,
           setLastBuildError,
+          disableCssWatcher ? undefined : refreshCssWatcher,
         );
       });
 
@@ -932,10 +950,11 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
           configPath,
           staticDir,
           logger,
-          wsServer,
+          disableWsReload ? null : wsServer,
           isBuildingRef,
           pendingChangesRef,
           setLastBuildError,
+          disableCssWatcher ? undefined : refreshCssWatcher,
         );
       });
 
@@ -944,6 +963,12 @@ export async function createDevServer(options: DevServerOptions = {}): Promise<D
       logger.info?.(`  • ${outDir}`);
       logger.info?.('Watching:');
       watchPaths.forEach((path) => logger.info?.(`  • ${path}`));
+      if (disableCssWatcher) {
+        logger.info?.('  • [diagnostic] CSS output watcher disabled');
+      }
+      if (disableWsReload) {
+        logger.info?.('  • [diagnostic] WebSocket reload broadcast disabled');
+      }
       logger.info?.('');
 
       // Open browser if requested

--- a/packages/core/src/core/dev.ts
+++ b/packages/core/src/core/dev.ts
@@ -279,7 +279,7 @@ async function performIncrementalRebuild(
         await onBuildEnd();
       } catch (error) {
         logger.error?.(
-          `Failed CSS watcher refresh after build: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed post-build hook after rebuild: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/packages/core/src/core/utils/dev-css-watcher.utils.ts
+++ b/packages/core/src/core/utils/dev-css-watcher.utils.ts
@@ -3,6 +3,7 @@ import fg from 'fast-glob';
 import type { FSWatcher } from 'chokidar';
 import type { WebSocketServer } from 'ws';
 import type { Logger } from '../../types/index.js';
+import { pathExists } from './fs.utils.js';
 
 /**
  * Returns concrete CSS files currently present in outDir.
@@ -11,6 +12,10 @@ import type { Logger } from '../../types/index.js';
  * which can add significant overhead on large docs sites.
  */
 export async function discoverOutputCssFiles(outDir: string): Promise<string[]> {
+  if (!(await pathExists(outDir))) {
+    return [];
+  }
+
   const cssFiles = await fg('**/*.css', {
     cwd: outDir,
     absolute: true,

--- a/packages/core/src/core/utils/dev-css-watcher.utils.ts
+++ b/packages/core/src/core/utils/dev-css-watcher.utils.ts
@@ -1,0 +1,97 @@
+import chokidar from 'chokidar';
+import fg from 'fast-glob';
+import type { FSWatcher } from 'chokidar';
+import type { WebSocketServer } from 'ws';
+import type { Logger } from '../../types/index.js';
+
+/**
+ * Returns concrete CSS files currently present in outDir.
+ *
+ * Watching explicit files avoids a broad recursive outDir glob watcher,
+ * which can add significant overhead on large docs sites.
+ */
+export async function discoverOutputCssFiles(outDir: string): Promise<string[]> {
+  const cssFiles = await fg('**/*.css', {
+    cwd: outDir,
+    absolute: true,
+    onlyFiles: true,
+    dot: false,
+  });
+
+  return cssFiles;
+}
+
+function hasSameMembership(nextFiles: string[], watchedCssFiles: Set<string>): boolean {
+  if (nextFiles.length !== watchedCssFiles.size) {
+    return false;
+  }
+  return nextFiles.every((file) => watchedCssFiles.has(file));
+}
+
+function broadcastReload(
+  wsServer: WebSocketServer | null,
+  disableWsReload: boolean,
+  payload: string,
+): void {
+  if (!wsServer || disableWsReload) {
+    return;
+  }
+
+  wsServer.clients.forEach((client: unknown) => {
+    const ws = client as { readyState: number; send: (data: string) => void };
+    if (ws.readyState === 1) {
+      ws.send(payload);
+    }
+  });
+}
+
+export interface RefreshCssOutputWatcherParams {
+  outDir: string;
+  logger: Logger;
+  wsServer: WebSocketServer | null;
+  disableWsReload: boolean;
+  cssWatcher: FSWatcher | null;
+  watchedCssFiles: Set<string>;
+}
+
+/**
+ * Reconciles the CSS watcher with the current output CSS file membership.
+ *
+ * If the file set changed, this closes the previous watcher and creates a new one
+ * bound to the latest concrete files.
+ */
+export async function refreshCssOutputWatcher(
+  params: RefreshCssOutputWatcherParams,
+): Promise<FSWatcher | null> {
+  const { outDir, logger, wsServer, disableWsReload, cssWatcher, watchedCssFiles } = params;
+
+  const cssFiles = await discoverOutputCssFiles(outDir);
+  if (hasSameMembership(cssFiles, watchedCssFiles)) {
+    return cssWatcher;
+  }
+
+  if (cssWatcher) {
+    await cssWatcher.close();
+  }
+
+  watchedCssFiles.clear();
+  cssFiles.forEach((file) => watchedCssFiles.add(file));
+
+  if (cssFiles.length === 0) {
+    return null;
+  }
+
+  const nextCssWatcher = chokidar.watch(cssFiles, {
+    ignored: /(^|[/\\])\../,
+    persistent: true,
+    ignoreInitial: true,
+  });
+
+  nextCssWatcher.on('change', (path: string) => {
+    const relativePath = path.replace(process.cwd(), '').replace(/\\/g, '/').replace(/^\//, '');
+    logger.info?.(`▸ ${relativePath} updated`);
+    broadcastReload(wsServer, disableWsReload, JSON.stringify({ type: 'reload' }));
+  });
+
+  return nextCssWatcher;
+}

--- a/packages/core/src/core/utils/env.utils.ts
+++ b/packages/core/src/core/utils/env.utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Parses common truthy environment flag values.
+ */
+export function isEnabledEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}

--- a/packages/core/src/core/utils/index.ts
+++ b/packages/core/src/core/utils/index.ts
@@ -115,3 +115,10 @@ export type { CompileOptions, WatchOptions } from './typescript.utils.js';
 
 // HTML manipulation utilities
 export { findHeadClosePosition, injectBeforeHeadClose } from './html.utils.js';
+
+// Environment utilities
+export { isEnabledEnvFlag } from './env.utils.js';
+
+// Dev-server CSS watcher utilities
+export { discoverOutputCssFiles, refreshCssOutputWatcher } from './dev-css-watcher.utils.js';
+export type { RefreshCssOutputWatcherParams } from './dev-css-watcher.utils.js';

--- a/packages/core/test/core/dev-css-watcher.test.ts
+++ b/packages/core/test/core/dev-css-watcher.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { createDevServer } from '../../src/core/dev.js';
+import { refreshCssOutputWatcher } from '../../src/core/utils/dev-css-watcher.utils.js';
 import { loadConfig } from '../../src/config/loader.js';
 import { build } from '../../src/core/build.js';
 import { invalidate } from '../../src/core/invalidate.js';
 import * as fsUtils from '../../src/core/utils/fs.utils.js';
 
-const { mockFg, createdWatchers } = vi.hoisted(() => ({
+const { mockFg, createdWatchers, createdWsServers } = vi.hoisted(() => ({
   mockFg: vi.fn(),
   createdWatchers: [] as Array<{
     on: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
     emit: (event: string, value?: string) => void;
+  }>,
+  createdWsServers: [] as Array<{
+    on: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    clients: Set<unknown>;
   }>,
 }));
 
@@ -24,11 +30,15 @@ vi.mock('fast-glob', () => ({
 }));
 
 vi.mock('ws', () => ({
-  WebSocketServer: vi.fn(() => ({
-    on: vi.fn(),
-    close: vi.fn(),
-    clients: new Set(),
-  })),
+  WebSocketServer: vi.fn(() => {
+    const wsServer = {
+      on: vi.fn(),
+      close: vi.fn(),
+      clients: new Set<unknown>(),
+    };
+    createdWsServers.push(wsServer);
+    return wsServer;
+  }),
 }));
 
 vi.mock('http', () => ({
@@ -128,6 +138,9 @@ describe('Dev Server CSS watcher reconciliation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     createdWatchers.length = 0;
+    createdWsServers.length = 0;
+    delete process.env.STATI_DEV_DISABLE_CSS_WATCHER;
+    delete process.env.STATI_DEV_DISABLE_WS_RELOAD;
 
     vi.mocked(fsUtils.pathExists).mockResolvedValue(true);
 
@@ -208,5 +221,124 @@ describe('Dev Server CSS watcher reconciliation', () => {
     expect(mockFg).not.toHaveBeenCalled();
 
     await devServer.stop();
+  });
+
+  it('logs diagnostics and skips CSS watcher when CSS watcher env flag is enabled', async () => {
+    process.env.STATI_DEV_DISABLE_CSS_WATCHER = '1';
+
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3193, logger });
+    await devServer.start();
+
+    // Only source/static watcher should exist when CSS watcher is disabled.
+    expect(createdWatchers).toHaveLength(1);
+    expect(mockFg).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('  • [diagnostic] CSS output watcher disabled');
+
+    await devServer.stop();
+  });
+
+  it('suppresses WebSocket reload broadcasts when reload env flag is enabled', async () => {
+    process.env.STATI_DEV_DISABLE_WS_RELOAD = 'true';
+
+    const cssA = 'C:/repo/dist/styles.css';
+    mockFg.mockResolvedValueOnce([cssA]).mockResolvedValueOnce([cssA]);
+
+    const wsClient = { readyState: 1, send: vi.fn() };
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3194, logger });
+    await devServer.start();
+
+    expect(createdWsServers).toHaveLength(1);
+    createdWsServers[0]!.clients.add(wsClient);
+
+    // Trigger source rebuild path (performIncrementalRebuild).
+    createdWatchers[0]!.emit('change', 'site/index.md');
+    await waitFor(() => mockBuild.mock.calls.length >= 2);
+
+    // Trigger CSS output watcher change path (broadcastReload helper).
+    expect(createdWatchers[1]).toBeDefined();
+    createdWatchers[1]!.emit('change', cssA);
+
+    expect(wsClient.send).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      '  • [diagnostic] WebSocket reload broadcast disabled',
+    );
+
+    await devServer.stop();
+  });
+
+  it('logs post-build hook errors when CSS watcher refresh fails', async () => {
+    const cssA = 'C:/repo/dist/styles.css';
+    mockFg.mockResolvedValueOnce([cssA]).mockRejectedValueOnce(new Error('scan failed'));
+
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3195, logger });
+    await devServer.start();
+
+    createdWatchers[0]!.emit('change', 'site/index.md');
+
+    await waitFor(() =>
+      logger.error.mock.calls.some(
+        (call) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('Failed post-build hook after rebuild: scan failed'),
+      ),
+    );
+
+    await devServer.stop();
+  });
+});
+
+describe('refreshCssOutputWatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdWatchers.length = 0;
+    vi.mocked(fsUtils.pathExists).mockResolvedValue(true);
+  });
+
+  it('returns null and closes previous watcher when CSS output becomes empty', async () => {
+    const existingWatcher = {
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as { close: () => Promise<void> };
+
+    mockFg.mockResolvedValueOnce([]);
+
+    const result = await refreshCssOutputWatcher({
+      outDir: 'dist',
+      logger: createLogger(),
+      wsServer: null,
+      disableWsReload: false,
+      cssWatcher: existingWatcher as never,
+      watchedCssFiles: new Set(['C:/repo/dist/styles.css']),
+    });
+
+    expect(existingWatcher.close).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('broadcasts reload only to open websocket clients', async () => {
+    const cssA = 'C:/repo/dist/styles.css';
+    mockFg.mockResolvedValueOnce([cssA]);
+
+    const logger = createLogger();
+    const openClient = { readyState: 1, send: vi.fn() };
+    const closedClient = { readyState: 3, send: vi.fn() };
+
+    const watcher = await refreshCssOutputWatcher({
+      outDir: 'dist',
+      logger,
+      wsServer: { clients: new Set([openClient, closedClient]) } as never,
+      disableWsReload: false,
+      cssWatcher: null,
+      watchedCssFiles: new Set(),
+    });
+
+    expect(watcher).not.toBeNull();
+    createdWatchers[0]!.emit('change', cssA);
+
+    expect(logger.info).toHaveBeenCalledWith('▸ C:/repo/dist/styles.css updated');
+    expect(openClient.send).toHaveBeenCalledWith(JSON.stringify({ type: 'reload' }));
+    expect(closedClient.send).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/test/core/dev-css-watcher.test.ts
+++ b/packages/core/test/core/dev-css-watcher.test.ts
@@ -4,6 +4,7 @@ import { createDevServer } from '../../src/core/dev.js';
 import { loadConfig } from '../../src/config/loader.js';
 import { build } from '../../src/core/build.js';
 import { invalidate } from '../../src/core/invalidate.js';
+import * as fsUtils from '../../src/core/utils/fs.utils.js';
 
 const { mockFg, createdWatchers } = vi.hoisted(() => ({
   mockFg: vi.fn(),
@@ -61,6 +62,10 @@ vi.mock('chokidar', () => ({
       return watcher;
     }),
   },
+}));
+
+vi.mock('../../src/core/utils/fs.utils.js', () => ({
+  pathExists: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../../src/config/loader.js', () => ({
@@ -124,6 +129,8 @@ describe('Dev Server CSS watcher reconciliation', () => {
     vi.clearAllMocks();
     createdWatchers.length = 0;
 
+    vi.mocked(fsUtils.pathExists).mockResolvedValue(true);
+
     mockLoadConfig.mockResolvedValue({
       srcDir: 'site',
       outDir: 'dist',
@@ -185,6 +192,20 @@ describe('Dev Server CSS watcher reconciliation', () => {
 
     expect(createdWatchers).toHaveLength(2);
     expect(createdWatchers[1]!.close).not.toHaveBeenCalled();
+
+    await devServer.stop();
+  });
+
+  it('starts without CSS watcher when outDir does not exist after initial build', async () => {
+    vi.mocked(fsUtils.pathExists).mockResolvedValue(false);
+
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3192, logger });
+    await devServer.start();
+
+    // Only the source/static watcher should be created; no CSS watcher.
+    expect(createdWatchers).toHaveLength(1);
+    expect(mockFg).not.toHaveBeenCalled();
 
     await devServer.stop();
   });

--- a/packages/core/test/core/dev-css-watcher.test.ts
+++ b/packages/core/test/core/dev-css-watcher.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { createDevServer } from '../../src/core/dev.js';
+import { loadConfig } from '../../src/config/loader.js';
+import { build } from '../../src/core/build.js';
+import { invalidate } from '../../src/core/invalidate.js';
+
+const { mockFg, createdWatchers } = vi.hoisted(() => ({
+  mockFg: vi.fn(),
+  createdWatchers: [] as Array<{
+    on: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    emit: (event: string, value?: string) => void;
+  }>,
+}));
+
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockBuild = vi.mocked(build);
+const mockInvalidate = vi.mocked(invalidate);
+
+vi.mock('fast-glob', () => ({
+  default: mockFg,
+}));
+
+vi.mock('ws', () => ({
+  WebSocketServer: vi.fn(() => ({
+    on: vi.fn(),
+    close: vi.fn(),
+    clients: new Set(),
+  })),
+}));
+
+vi.mock('http', () => ({
+  createServer: vi.fn(() => ({
+    listen: vi.fn((_port: number, _host: string, callback?: () => void) => {
+      if (callback) callback();
+    }),
+    close: vi.fn((callback?: () => void) => {
+      if (callback) callback();
+    }),
+    on: vi.fn(),
+  })),
+}));
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => {
+      const handlers = new Map<string, (value: string) => void>();
+      const watcher = {
+        on: vi.fn((event: string, cb: (value: string) => void) => {
+          handlers.set(event, cb);
+          return watcher;
+        }),
+        close: vi.fn().mockResolvedValue(undefined),
+        emit: (event: string, value = '') => {
+          const cb = handlers.get(event);
+          if (cb) cb(value);
+        },
+      };
+      createdWatchers.push(watcher);
+      return watcher;
+    }),
+  },
+}));
+
+vi.mock('../../src/config/loader.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('../../src/core/build.js', () => ({
+  build: vi.fn(),
+}));
+
+vi.mock('../../src/core/invalidate.js', () => ({
+  invalidate: vi.fn(),
+}));
+
+vi.mock('../../src/core/templates.js', () => ({
+  clearTemplateEngineCache: vi.fn(),
+}));
+
+vi.mock('../../src/core/markdown.js', () => ({
+  clearMarkdownProcessorCache: vi.fn(),
+}));
+
+vi.mock('../../src/core/isg/index.js', () => ({
+  loadCacheManifest: vi.fn().mockResolvedValue(null),
+  saveCacheManifest: vi.fn().mockResolvedValue(undefined),
+  computeNavigationHash: vi.fn().mockReturnValue('hash123'),
+  DevServerLockManager: class {
+    async acquireLock() {
+      return Promise.resolve();
+    }
+    async releaseLock() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    status: vi.fn(),
+    building: vi.fn(),
+    processing: vi.fn(),
+    stats: vi.fn(),
+  };
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await sleep(10);
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+describe('Dev Server CSS watcher reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdWatchers.length = 0;
+
+    mockLoadConfig.mockResolvedValue({
+      srcDir: 'site',
+      outDir: 'dist',
+      staticDir: 'public',
+      site: { title: 'Test Site', baseUrl: 'http://localhost:3000' },
+    });
+
+    mockBuild.mockResolvedValue({
+      totalPages: 1,
+      assetsCount: 1,
+      buildTimeMs: 5,
+      outputSizeBytes: 128,
+    });
+
+    mockInvalidate.mockResolvedValue({
+      invalidatedCount: 1,
+      invalidatedPaths: ['/'],
+      clearedAll: true,
+    });
+  });
+
+  it('recreates CSS watcher when output CSS files change after rebuild', async () => {
+    const cssA = 'C:/repo/dist/styles.css';
+    const cssB = 'C:/repo/dist/chunk.css';
+
+    mockFg.mockResolvedValueOnce([cssA]).mockResolvedValueOnce([cssA, cssB]);
+
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3190, logger });
+    await devServer.start();
+
+    expect(createdWatchers).toHaveLength(2);
+
+    // Source/static watcher is created first and drives incremental rebuilds.
+    createdWatchers[0]!.emit('change', 'public/file.txt');
+
+    await waitFor(() => createdWatchers.length === 3);
+
+    // The old CSS watcher should be closed, then recreated with new file set.
+    expect(createdWatchers[1]!.close).toHaveBeenCalledTimes(1);
+
+    await devServer.stop();
+  });
+
+  it('does not recreate CSS watcher when output CSS files are unchanged', async () => {
+    const cssA = 'C:/repo/dist/styles.css';
+
+    mockFg.mockResolvedValueOnce([cssA]).mockResolvedValueOnce([cssA]);
+
+    const logger = createLogger();
+    const devServer = await createDevServer({ port: 3191, logger });
+    await devServer.start();
+
+    expect(createdWatchers).toHaveLength(2);
+
+    createdWatchers[0]!.emit('change', 'public/file.txt');
+
+    await waitFor(() => mockBuild.mock.calls.length >= 2);
+
+    expect(createdWatchers).toHaveLength(2);
+    expect(createdWatchers[1]!.close).not.toHaveBeenCalled();
+
+    await devServer.stop();
+  });
+});

--- a/packages/core/test/core/dev.test.ts
+++ b/packages/core/test/core/dev.test.ts
@@ -7,6 +7,10 @@ import { build } from '../../src/core/build.js';
 import { invalidate } from '../../src/core/invalidate.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
+const { mockFg } = vi.hoisted(() => ({
+  mockFg: vi.fn(),
+}));
+
 // Store the request handler for testing
 let capturedRequestHandler: ((req: IncomingMessage, res: ServerResponse) => void) | null = null;
 
@@ -43,6 +47,10 @@ vi.mock('chokidar', () => ({
       close: vi.fn(() => Promise.resolve()),
     })),
   },
+}));
+
+vi.mock('fast-glob', () => ({
+  default: mockFg,
 }));
 
 vi.mock('open', () => ({
@@ -151,11 +159,13 @@ describe('Development Server', () => {
   const mockLoadConfig = vi.mocked(loadConfig);
   const mockBuild = vi.mocked(build);
   const mockInvalidate = vi.mocked(invalidate);
+  const mockDiscoverOutputCssFiles = vi.mocked(mockFg);
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.clearAllMocks();
     capturedRequestHandler = null;
+    mockDiscoverOutputCssFiles.mockResolvedValue([]);
 
     // Ensure mocks return valid data
     mockLoadConfig.mockResolvedValue({
@@ -607,6 +617,7 @@ describe('Development Server', () => {
       const chokidar = await import('chokidar');
       const mockWatch = vi.mocked(chokidar.default.watch);
       mockWatch.mockClear();
+      mockDiscoverOutputCssFiles.mockResolvedValueOnce(['C:/repo/dist/styles.css']);
 
       mockLoadConfig.mockResolvedValueOnce({
         srcDir: 'site',
@@ -636,6 +647,7 @@ describe('Development Server', () => {
     it('should trigger reload without rebuild when CSS file changes', async () => {
       const chokidar = await import('chokidar');
       const mockWatch = vi.mocked(chokidar.default.watch);
+      mockDiscoverOutputCssFiles.mockResolvedValueOnce(['C:/repo/dist/styles.css']);
 
       // Store the change handler for CSS watcher
       let cssChangeHandler: ((path: string) => void) | undefined;
@@ -700,6 +712,7 @@ describe('Development Server', () => {
     it('should close CSS watcher on stop', async () => {
       const chokidar = await import('chokidar');
       const mockWatch = vi.mocked(chokidar.default.watch);
+      mockDiscoverOutputCssFiles.mockResolvedValueOnce(['C:/repo/dist/styles.css']);
 
       const mockCssWatcherClose = vi.fn(() => Promise.resolve());
       let watcherIndex = 0;

--- a/packages/core/test/core/dev.test.ts
+++ b/packages/core/test/core/dev.test.ts
@@ -6,6 +6,7 @@ import { loadConfig } from '../../src/config/loader.js';
 import { build } from '../../src/core/build.js';
 import { invalidate } from '../../src/core/invalidate.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import * as fsUtils from '../../src/core/utils/fs.utils.js';
 
 const { mockFg } = vi.hoisted(() => ({
   mockFg: vi.fn(),
@@ -55,6 +56,10 @@ vi.mock('fast-glob', () => ({
 
 vi.mock('open', () => ({
   default: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/core/utils/fs.utils.js', () => ({
+  pathExists: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../../src/config/loader.js', () => ({
@@ -166,6 +171,7 @@ describe('Development Server', () => {
     vi.clearAllMocks();
     capturedRequestHandler = null;
     mockDiscoverOutputCssFiles.mockResolvedValue([]);
+    vi.mocked(fsUtils.pathExists).mockResolvedValue(true);
 
     // Ensure mocks return valid data
     mockLoadConfig.mockResolvedValue({

--- a/packages/core/test/perf/dev-server-rebuild.test.ts
+++ b/packages/core/test/perf/dev-server-rebuild.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Dev-server REAL rebuild-time repro.
+ *
+ * Unlike dev-server-leak.test.ts (which drives build() directly), this boots the
+ * actual createDevServer() so all dev-only machinery participates: chokidar
+ * watchers, TS esbuild watch contexts, WebSocket server, manifest load/save and
+ * the handleTemplateChange path. The reported user symptom is rebuild time that
+ * creeps upward across consecutive layout.eta edits AND worsens with idle time.
+ *
+ * This test edits layout.eta repeatedly, sleeps between edits, and captures the
+ * "pages rebuilt in Xms" duration the dev server logs. It asserts the late
+ * window is not dramatically slower than the early window.
+ *
+ * Run: npx vitest run packages/core/test/perf/dev-server-rebuild.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { createDevServer } from '../../src/core/dev.js';
+import { setEnv } from '../../src/env.js';
+
+const PAGES = 40;
+const EDITS = 24;
+const IDLE_MS = 700;
+
+function createCapturingLogger(durations: number[]) {
+  const noop = () => {};
+  return {
+    info: (msg?: string) => {
+      if (typeof msg === 'string') {
+        const m = msg.match(/in (\d+)ms/);
+        if (m) durations.push(Number(m[1]));
+      }
+    },
+    success: noop,
+    warning: noop,
+    error: noop,
+    status: noop,
+    building: noop,
+    processing: noop,
+    stats: noop,
+    startProgress: noop,
+    updateProgress: noop,
+    endProgress: noop,
+  };
+}
+
+function fixture(base: string): void {
+  const site = join(base, 'site');
+  const pub = join(base, 'public');
+  const partials = join(site, '_partials');
+  mkdirSync(partials, { recursive: true });
+  mkdirSync(pub, { recursive: true });
+  const big = Array.from(
+    { length: 60 },
+    (_, k) => `## H ${k}\n\nLorem ipsum dolor sit amet ${k}. \n\n\`\`\`js\nconst x=${k};\n\`\`\`\n`,
+  ).join('\n');
+  for (let i = 0; i < PAGES; i++) {
+    writeFileSync(
+      join(site, `page-${i}.md`),
+      `---\ntitle: Page ${i}\n---\n\n# Page ${i}\n\n${big}\n`,
+    );
+  }
+  writeFileSync(join(site, 'index.md'), `---\ntitle: Home\n---\n\n# Home\n`);
+  for (let p = 0; p < 12; p++) {
+    writeFileSync(join(partials, `p${p}.eta`), `<div>partial ${p} <%= stati.page.title %></div>`);
+  }
+  writeFileSync(join(partials, 'header.eta'), `<header>hdr</header>`);
+  writeFileSync(join(pub, 'styles.css'), 'body{margin:0}');
+  writeFileSync(
+    join(base, 'stati.config.js'),
+    `export default { site: { title: 'Repro', baseUrl: 'https://x.test' }, srcDir: 'site', outDir: 'dist', staticDir: 'public', search: { enabled: true } };\n`,
+  );
+}
+
+function layout(site: string, n: number): void {
+  writeFileSync(
+    join(site, 'layout.eta'),
+    `<!DOCTYPE html><html><head><title><%= stati.page.title %> r${n}</title></head><body><main><%~ stati.content %></main><!-- r${n} --></body></html>`,
+  );
+}
+
+const median = (v: number[]) => {
+  const s = [...v].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)] ?? 0;
+};
+
+describe('Dev server real rebuild creep', () => {
+  let dir: string;
+  let cwd: string;
+  let server: Awaited<ReturnType<typeof createDevServer>>;
+  const durations: number[] = [];
+
+  beforeAll(async () => {
+    dir = join(tmpdir(), `stati-devrepro-${randomUUID()}`);
+    mkdirSync(dir, { recursive: true });
+    fixture(dir);
+    layout(join(dir, 'site'), 0);
+    cwd = process.cwd();
+    process.chdir(dir);
+    setEnv('development');
+    server = await createDevServer({
+      port: 4599,
+      host: '127.0.0.1',
+      logger: createCapturingLogger(durations),
+    });
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    process.chdir(cwd);
+    setEnv('test');
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('does not slow down across many layout edits with idle gaps', async () => {
+    const site = join(dir, 'site');
+    durations.length = 0;
+    for (let i = 1; i <= EDITS; i++) {
+      const before = durations.length;
+      layout(site, i);
+      // wait for rebuild to be reported
+      for (let t = 0; t < 100 && durations.length === before; t++) await sleep(50);
+      await sleep(IDLE_MS);
+    }
+    const w = Math.max(2, Math.floor(durations.length / 4));
+    const early = median(durations.slice(0, w));
+    const late = median(durations.slice(-w));
+    console.warn(
+      `[DEVREPRO] n=${durations.length} early=${early}ms late=${late}ms all=${durations.join(',')}`,
+    );
+    expect(late).toBeLessThan(early * 1.6);
+  }, 120000);
+});

--- a/packages/core/test/utils/env.utils.test.ts
+++ b/packages/core/test/utils/env.utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isEnabledEnvFlag } from '../../src/core/utils/env.utils.js';
+
+describe('isEnabledEnvFlag', () => {
+  it('returns true for supported truthy values', () => {
+    expect(isEnabledEnvFlag('1')).toBe(true);
+    expect(isEnabledEnvFlag('true')).toBe(true);
+    expect(isEnabledEnvFlag('yes')).toBe(true);
+    expect(isEnabledEnvFlag('on')).toBe(true);
+  });
+
+  it('is case-insensitive for supported values', () => {
+    expect(isEnabledEnvFlag('TRUE')).toBe(true);
+    expect(isEnabledEnvFlag('Yes')).toBe(true);
+    expect(isEnabledEnvFlag('On')).toBe(true);
+  });
+
+  it('returns false for undefined, empty, or unsupported values', () => {
+    expect(isEnabledEnvFlag(undefined)).toBe(false);
+    expect(isEnabledEnvFlag('')).toBe(false);
+    expect(isEnabledEnvFlag('0')).toBe(false);
+    expect(isEnabledEnvFlag('false')).toBe(false);
+    expect(isEnabledEnvFlag('off')).toBe(false);
+    expect(isEnabledEnvFlag('random')).toBe(false);
+  });
+});

--- a/scripts/check-dev-server-slowdown.mjs
+++ b/scripts/check-dev-server-slowdown.mjs
@@ -96,7 +96,7 @@ function printReport(report) {
 }
 
 function escapeMarkdown(value) {
-  return String(value).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return String(value).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
 }
 
 function renderReportMarkdown(report) {

--- a/scripts/check-dev-server-slowdown.mjs
+++ b/scripts/check-dev-server-slowdown.mjs
@@ -1,0 +1,251 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { createDevServer } from '../packages/core/dist/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '..');
+const docsSiteDir = join(repoRoot, 'docs-site');
+const layoutPath = join(docsSiteDir, 'site', 'layout.eta');
+
+const ITERATIONS = Number(process.env.STATI_DEV_CHECK_EDITS || '20');
+const IDLE_MS = Number(process.env.STATI_DEV_CHECK_IDLE_MS || '700');
+const PORT = Number(process.env.STATI_DEV_CHECK_PORT || '4789');
+const HOST = process.env.STATI_DEV_CHECK_HOST || '127.0.0.1';
+const MAX_RATIO = Number(process.env.STATI_DEV_CHECK_MAX_RATIO || '1.25');
+const REPORT_PATH = process.env.STATI_DEV_CHECK_REPORT_PATH || '';
+
+function median(values) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)] || 0;
+}
+
+function formatMs(value) {
+  return `${value}ms`;
+}
+
+function formatRatio(value) {
+  if (!Number.isFinite(value)) return 'n/a';
+  return `${value.toFixed(2)}x`;
+}
+
+function formatChange(early, late) {
+  const delta = late - early;
+  const percent = early > 0 ? (delta / early) * 100 : 0;
+  const deltaPrefix = delta >= 0 ? '+' : '';
+  const percentPrefix = percent >= 0 ? '+' : '';
+  return `${deltaPrefix}${delta}ms (${percentPrefix}${percent.toFixed(1)}%)`;
+}
+
+function buildReport({
+  iterations,
+  validCount,
+  idleMs,
+  early,
+  late,
+  ratio,
+  threshold,
+  cssWatcherDisabled,
+  wsReloadDisabled,
+  passed,
+  reason,
+}) {
+  return {
+    iterations,
+    validCount,
+    idleMs,
+    early,
+    late,
+    ratio,
+    threshold,
+    cssWatcherDisabled,
+    wsReloadDisabled,
+    passed,
+    reason,
+    rows: [
+      ['Result', passed ? 'PASS' : 'FAIL'],
+      ['Edits completed', `${validCount}/${iterations}`],
+      ['Idle between edits', formatMs(idleMs)],
+      ['Early median', formatMs(early)],
+      ['Late median', formatMs(late)],
+      ['Change', formatChange(early, late)],
+      ['Ratio', formatRatio(ratio)],
+      ['Threshold', `${threshold.toFixed(2)}x`],
+      ['CSS watcher', cssWatcherDisabled ? 'disabled' : 'enabled'],
+      ['WS reload', wsReloadDisabled ? 'disabled' : 'enabled'],
+    ],
+  };
+}
+
+function printReport(report) {
+  const { rows, reason } = report;
+  const labelWidth = Math.max(...rows.map(([label]) => label.length), 18);
+
+  console.log('Dev server rebuild slowdown check');
+  console.log('');
+  for (const [label, value] of rows) {
+    console.log(`${label.padEnd(labelWidth)} : ${value}`);
+  }
+  if (reason) {
+    console.log('');
+    console.log(`Reason${' '.repeat(labelWidth - 6)} : ${reason}`);
+  }
+}
+
+function escapeMarkdown(value) {
+  return String(value).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function renderReportMarkdown(report) {
+  const statusEmoji = report.passed ? 'PASS' : 'FAIL';
+  const feedbackLine = report.passed
+    ? 'Feedback: no slowdown detected.'
+    : `Feedback: slowdown detected and this check failed because ${report.reason}.`;
+  const lines = [
+    '## Dev Server Slowdown Check',
+    '',
+    `Status: **${statusEmoji}**`,
+    '',
+    feedbackLine,
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+  ];
+
+  for (const [label, value] of report.rows) {
+    lines.push(`| ${escapeMarkdown(label)} | ${escapeMarkdown(value)} |`);
+  }
+
+  if (report.reason) {
+    lines.push('', `Reason: ${escapeMarkdown(report.reason)}`);
+  }
+
+  lines.push('', `Generated at: ${new Date().toISOString()}`);
+  return lines.join('\n');
+}
+
+async function waitForDurationCount(durations, beforeCount, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (durations.length > beforeCount) return true;
+    await sleep(50);
+  }
+  return false;
+}
+
+async function main() {
+  const originalCwd = process.cwd();
+  const originalLayout = await readFile(layoutPath, 'utf-8');
+  const reportPath = REPORT_PATH ? join(repoRoot, REPORT_PATH) : '';
+  const durations = [];
+  const marks = [];
+
+  const logger = {
+    info: (msg) => {
+      if (typeof msg !== 'string') return;
+      const pagesMatch = msg.match(/pages rebuilt in (\d+)ms/);
+      if (pagesMatch) {
+        durations.push(Number(pagesMatch[1]));
+        return;
+      }
+      const doneMatch = msg.match(/Done in (\d+)ms/);
+      if (doneMatch) {
+        durations.push(Number(doneMatch[1]));
+      }
+    },
+    success: () => {},
+    warning: (msg) => {
+      if (msg) console.log(`[WARN] ${msg}`);
+    },
+    error: (msg) => {
+      if (msg) console.log(`[ERROR] ${msg}`);
+    },
+    status: (msg) => {
+      if (msg) console.log(`[STATUS] ${msg}`);
+    },
+    building: () => {},
+    processing: () => {},
+    stats: () => {},
+    startProgress: () => {},
+    updateProgress: () => {},
+    endProgress: () => {},
+  };
+
+  process.chdir(docsSiteDir);
+  const server = await createDevServer({ port: PORT, host: HOST, logger });
+
+  try {
+    await server.start();
+    await sleep(1000);
+
+    for (let i = 1; i <= ITERATIONS; i++) {
+      const beforeCount = durations.length;
+      const marker = `\n<!-- check-layout-edit-${i}-${Date.now()} -->\n`;
+      await writeFile(layoutPath, originalLayout + marker, 'utf-8');
+
+      const rebuilt = await waitForDurationCount(durations, beforeCount);
+      const lastDuration = durations[durations.length - 1] || -1;
+      const rssMb = Math.round(process.memoryUsage().rss / 1024 / 1024);
+      marks.push({ i, rebuilt, durationMs: lastDuration, rssMb });
+
+      if (!rebuilt) {
+        console.log(`[CHECK] edit #${i}: timeout waiting for rebuild`);
+        break;
+      }
+
+      console.log(`[CHECK] #${i} ${lastDuration}ms rss=${rssMb}MB`);
+      await sleep(IDLE_MS);
+    }
+
+    const valid = marks.filter((m) => m.rebuilt).map((m) => m.durationMs);
+    const sampleWindow = Math.max(2, Math.floor(valid.length / 4));
+    const early = median(valid.slice(0, sampleWindow));
+    const late = median(valid.slice(-sampleWindow));
+    const ratio = early > 0 ? late / early : Number.POSITIVE_INFINITY;
+    const cssWatcherDisabled = process.env.STATI_DEV_DISABLE_CSS_WATCHER === '1';
+    const wsReloadDisabled = process.env.STATI_DEV_DISABLE_WS_RELOAD === '1';
+    const reason =
+      valid.length < 4
+        ? `only ${valid.length} rebuild sample(s) were collected`
+        : ratio > MAX_RATIO
+          ? `late median is ${formatRatio(ratio)} of early median, above the ${MAX_RATIO.toFixed(2)}x threshold`
+          : '';
+    const passed = reason === '';
+
+    const report = buildReport({
+      iterations: ITERATIONS,
+      validCount: valid.length,
+      idleMs: IDLE_MS,
+      early,
+      late,
+      ratio,
+      threshold: MAX_RATIO,
+      cssWatcherDisabled,
+      wsReloadDisabled,
+      passed,
+      reason,
+    });
+
+    printReport(report);
+
+    if (reportPath) {
+      await writeFile(reportPath, `${renderReportMarkdown(report)}\n`, 'utf-8');
+    }
+
+    if (!passed) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await writeFile(layoutPath, originalLayout, 'utf-8');
+    await server.stop();
+    process.chdir(originalCwd);
+  }
+}
+
+main().catch((error) => {
+  console.error('[CHECK] failed', error);
+  process.exitCode = 1;
+});

--- a/scripts/check-dev-server-slowdown.mjs
+++ b/scripts/check-dev-server-slowdown.mjs
@@ -40,6 +40,11 @@ function formatChange(early, late) {
   return `${deltaPrefix}${delta}ms (${percentPrefix}${percent.toFixed(1)}%)`;
 }
 
+function isEnabledEnvFlag(value) {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
 function buildReport({
   iterations,
   validCount,
@@ -205,8 +210,8 @@ async function main() {
     const early = median(valid.slice(0, sampleWindow));
     const late = median(valid.slice(-sampleWindow));
     const ratio = early > 0 ? late / early : Number.POSITIVE_INFINITY;
-    const cssWatcherDisabled = process.env.STATI_DEV_DISABLE_CSS_WATCHER === '1';
-    const wsReloadDisabled = process.env.STATI_DEV_DISABLE_WS_RELOAD === '1';
+    const cssWatcherDisabled = isEnabledEnvFlag(process.env.STATI_DEV_DISABLE_CSS_WATCHER);
+    const wsReloadDisabled = isEnabledEnvFlag(process.env.STATI_DEV_DISABLE_WS_RELOAD);
     const reason =
       valid.length < 4
         ? `only ${valid.length} rebuild sample(s) were collected`


### PR DESCRIPTION
- Introduced a new script to check for dev server rebuild slowdown.
- Added environment utilities for enabling/disabling CSS watcher and WebSocket reload.
- Enhanced dev server to reconcile CSS watchers based on output files.
- Updated package.json with a new test script for slowdown checks.
- Created tests for CSS watcher functionality and environment flag utility.